### PR TITLE
mvoes to a newer base image for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     environment:
       IMAGE_NAME: openftth/route-network-validator
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:2020.09
   alpine-git:
     environment:
       IMAGE_NAME: openftth/gdb-integrator
@@ -21,9 +21,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Apt update
-          command: apt-get update;
-      - run:
           name: Restore
           command: dotnet restore
       - run:
@@ -34,9 +31,6 @@ jobs:
     executor: dotnet-core-sdk
     steps:
       - checkout
-      - run:
-          name: Apt update
-          command: apt-get update;
       - run:
           name: Test
           command: dotnet test


### PR DESCRIPTION
Moves to a newer version of the CircleCI base image.

The reason for the upgrade is described in the mail from CircleCI below.

-----

We want to let you know that on October 26th, 2020 we will begin descaling some of the machine images you’re currently using (listed below) . The image will continue to work for you but the average provisioning time will increase.

For a fast and reliable experience, we suggest updating to one of the supported Linux machine images below before October 26th. This will ensure CircleCI can maintain your image with the speed and support you’ve come to expect.

The images that will be deprecated no longer receive support from upstream projects. Canonical, the creator of Ubuntu, as well as Docker, no longer manage their images for security or bug fixes. This makes it difficult for us to keep these images operational and secure while maintaining newer images that are supported upstream.