### PR TITLE
hotfix ca for debian based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build-env
 WORKDIR /app
 
 COPY ./*sln ./


### PR DESCRIPTION
Changes to mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim to fix build errors in docker.

Link for issue:
https://github.com/NuGet/Home/issues/10491